### PR TITLE
Word wrapping, ingredient parsing, parts and notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ Currently for images to be displayed they have to be placed in the same folder t
 
 Then the recipe itself follows.
 
-Lines with ingredients are started with a '#'. After the hash, one can either
+Lines with ingredients are started with a '*'. After the star, one can either
 write the amount, unit and ingredient (e.g. 4tsp sugar) name, amount and name
 (e.g. 4 eggs), or just the ingredient if an amount is not neccesary (e.g.
 salt). The unit has to follow the amount directly, without whitespace
 in between. In cases when this is not sufficient, squared brackets around the
 unit can be used to separate the components in an explicit way (e.g. 1 [heaped tbsp.] sugar).
 
-Steps are started with a '\*', followed by the instruction.
+Steps are started with a '-', followed by the instruction.
 
 WaitPhase blocks start with a '+'.
 
@@ -81,22 +81,22 @@ As an example, a simple recipe for a quiche lorraine:
     This would be the description for this very nice recipe, which is actually
     legit and can be cooked like this.
     
-    # 200g speck
-    # 3pcs onion
-    * cut speck into cubes, onion into rings
-    * brown both together and let cool
+    * 200g speck
+    * 3pcs onion
+    - cut speck into cubes, onion into rings
+    - brown both together and let cool
     
-    # 3pcs egg
-    # 250ml heavy cream
-    # 125g Gruyère
-    * whisk egg and cream together
-    * grate Gruère, add to cream
-    * add speck mixture to cream
+    * 3pcs egg
+    * 250ml heavy cream
+    * 125g Gruyère
+    - whisk egg and cream together
+    - grate Gruère, add to cream
+    - add speck mixture to cream
     
-    # shortcrust pastry
-    * line dish with pastry
-    * fill pastry with the mixture
-    * bake in the preheated oven at 180°C, for 30 to 35 minutes
+    * shortcrust pastry
+    - line dish with pastry
+    - fill pastry with the mixture
+    - bake in the preheated oven at 180°C, for 30 to 35 minutes
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Lines with ingredients are started with a '#'. After the hash, one can either
 write the amount, unit and ingredient (e.g. 4tsp sugar) name, amount and name
 (e.g. 4 eggs), or just the ingredient if an amount is not neccesary (e.g.
 salt). The unit has to follow the amount directly, without whitespace
-inbetween.
+in between. In cases when this is not sufficient, squared brackets around the
+unit can be used to separate the components in an explicit way (e.g. 1 [heaped tbsp.] sugar).
 
 Steps are started with a '\*', followed by the instruction.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The metadata block is located at the beginning of the recipe block, ingredients
 and steps are mixed because of the intended output format. Ingredients for a
 specific block come first, then the steps to perform with the mentioned
 ingredients. Wait phases are steps in the recipe that primarily contain of
-waiting.
+waiting. Furthermore, the recipe can be separated into different parts.
 
 Currently metadata may contain
 - title / name
@@ -66,7 +66,7 @@ unit can be used to separate the components in an explicit way (e.g. 1 [heaped t
 
 Steps are started with a '-', followed by the instruction.
 
-WaitPhase blocks start with a '+'.
+WaitPhase blocks start with a '+' and a '#' is used to start a new part.
 
 Example
 -------

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ As an example, a simple recipe for a quiche lorraine:
     !author: uhu01
     !source: 
     !img: very_nice_image.png
+
     This would be the description for this very nice recipe, which is actually
     legit and can be cooked like this.
     

--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ The markdown format contains three types of information:
 - metadata
 - ingredients
 - steps
+- note
 - wait phases
 
 The metadata block is located at the beginning of the recipe block, ingredients
 and steps are mixed because of the intended output format. Ingredients for a
 specific block come first, then the steps to perform with the mentioned
-ingredients. Wait phases are steps in the recipe that primarily contain of
+ingredients. A note is similar to a step, but contains additional advice and is not numbered.
+Wait phases are steps in the recipe that primarily contain of
 waiting. Furthermore, the recipe can be separated into different parts.
 
 Currently metadata may contain
@@ -64,7 +66,7 @@ salt). The unit has to follow the amount directly, without whitespace
 in between. In cases when this is not sufficient, squared brackets around the
 unit can be used to separate the components in an explicit way (e.g. 1 [heaped tbsp.] sugar).
 
-Steps are started with a '-', followed by the instruction.
+Steps are started with a '-', followed by the instruction. For notes, '--' is used.
 
 WaitPhase blocks start with a '+' and a '#' is used to start a new part.
 

--- a/migrate.py
+++ b/migrate.py
@@ -1,0 +1,36 @@
+#!/bin/env python3
+
+"""Migrate old recipe markdown files by changing a few special characters."""
+
+import re
+import argparse
+
+replacements = {
+    '*': '-',
+    '#': '*',
+    '-': '#',
+}
+
+def repl(m):
+    return m.group(1) + replacements[m.group(2)]
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('file', nargs='+', type=argparse.FileType('r'), help='files to convert')
+    parser.add_argument('-r', '--reverse', action='store_true', help='reverse the replacements')
+    args = parser.parse_args()
+    if args.reverse:
+        global replacements
+        replacements = {v: k for k, v in replacements.items()}
+
+    for f in args.file:
+        contents = f.read()
+        contents = re.sub('^(\s*)([-#\*])', repl, contents, flags=re.MULTILINE)
+        f.close()
+        with open(f.name, 'w') as out:
+            out.write(contents)
+        print(f.name, 'updated')
+
+if __name__ == '__main__':
+    main()
+

--- a/parser.py
+++ b/parser.py
@@ -178,7 +178,7 @@ def parseFile(stream):
                     raise Exception('commands are not yet used (metadata must appear at the beginning of the recipe)')
 
             elif line.lineType == Line.Plain:
-                if len(recipe.phases):
+                if not recipe or len(recipe.phases):
                     raise Exception('plain lines are only allowed for description at the beginning of the recipe')
                 parseMeta('desc', line.contents, recipe)
 

--- a/parser.py
+++ b/parser.py
@@ -57,6 +57,17 @@ class Line:
         else:
             self._contents.append(contents)
 
+    def __eq__(self, other):
+        if not isinstance(other, Line):
+            return NotImplemented
+
+        return (self.lineType == other.lineType
+            and self.lineNo == other.lineNo
+            and self.contents == other.contents)
+
+    def __ne__(self, other):
+        return not self == other
+
 def preprocessLines(stream):
     """Generator that joins word wrapped lines back together and parses the type of the line,
     e.g. ingredient or step. Yields instances of the Line class.

--- a/parser.py
+++ b/parser.py
@@ -25,10 +25,10 @@ class Line:
     startCharacters = (
         ("'", Comment),
         ('!', Command),
-        ('=', Part),
-        ('#', Ingredient),
-        ('**', Note), # notes have to be parsed before instructions!
-        ('*', Step),
+        ('#', Part),
+        ('*', Ingredient),
+        ('--', Note), # notes have to be parsed before steps!
+        ('-', Step),
         ('+', WaitPhase),
     )
 

--- a/parser.py
+++ b/parser.py
@@ -199,7 +199,13 @@ def parseFile(stream):
                 phase.steps.append(Step(line.contents))
 
             elif line.lineType == Line.Note:
-                raise Exception('notes are not implemented yet')
+                if not recipe:
+                    raise Exception('note occurred outside of recipe')
+                meta = False
+                if not phase:
+                    phase = Phase()
+                    recipe.phases.append(phase)
+                phase.steps.append(Note(line.contents))
 
             elif line.lineType == Line.WaitPhase:
                 if not recipe:

--- a/parser.py
+++ b/parser.py
@@ -42,20 +42,14 @@ class Line:
 
     @property
     def contents(self):
-        if isinstance(self._contents, str):
-            return self._contents
-        else:
-            return ' '.join(self._contents)
+        return ' '.join(self._contents)
 
     @contents.setter
     def contents(self, contents):
-        self._contents = contents
+        self._contents = [contents]
 
     def append(self, contents):
-        if isinstance(self._contents, str):
-            self._contents = [self._contents, contents]
-        else:
-            self._contents.append(contents)
+        self._contents.append(contents)
 
     def __eq__(self, other):
         if not isinstance(other, Line):

--- a/parser.py
+++ b/parser.py
@@ -82,7 +82,7 @@ def preprocessLines(stream):
             else:
                 lineType = Line.Plain
 
-        if lineType != None:
+        if lineType != None and lineType != Line.Comment:
             if currentLine:
                 yield currentLine
             currentLine = Line(lineType, lineNo, contents)
@@ -218,7 +218,7 @@ def parseFile(stream):
                 meta = False # to allow progress images at the beginning of the recipe
                 if phase:
                     phase = None
-            elif line.lineType != Line.Comment:
+            else:
                 raise Exception('invalid line type')
 
     except Exception as e:

--- a/parser.py
+++ b/parser.py
@@ -173,7 +173,12 @@ def parseFile(stream):
                 parseMeta('desc', line.contents, recipe)
 
             elif line.lineType == Line.Part:
-                raise Exception('parts are not implemented yet')
+                if not recipe:
+                    raise Exception('part occurred outside of recipe')
+                meta = False
+                phase = None
+                part = Part(line.contents)
+                recipe.phases.append(part)
 
             elif line.lineType == Line.Ingredient:
                 if not recipe:

--- a/parser.py
+++ b/parser.py
@@ -130,11 +130,10 @@ def parseMeta(key, val, recipe):
     elif key == 'author':
         recipe.author = val
     elif key == 'desc':
-        if recipe.description == None:
-            recipe.description = val
+        if recipe.description is None:
+            recipe.description = [val]
         else:
-            #TODO: use a list with a string for each paragraph and extend the XML format
-            recipe.description = recipe.description.strip() + ' ' + val
+            recipe.description.append(val)
     elif key == 'keywords':
         kws = val.split(',')
         kws = [x.strip() for x in kws]

--- a/parser.py
+++ b/parser.py
@@ -90,17 +90,24 @@ def preprocessLines(stream):
         yield currentLine
 
 def parseIngredient(line):
-    r = r'^\s*([0-9/\.]+(?:\s+[0-9/]+)?)([a-zA-Z]+)?\s+(.*)'
-    result = re.match( r, line)
+    r = r'^(.+)\[(.*)\](.+)'
+    result = re.match(r, line)
+
+    if result is None:
+        r = r'^\s*([0-9/\.]+(?:\s+[0-9/]+)?)([a-zA-Z]+)?\s+(.*)'
+        result = re.match( r, line)
 
     if result is None:
         return Ingredient(line, None, None)
 
-    return Ingredient(
-        result.groups()[2].rstrip(),
-        result.groups()[0],
-        result.groups()[1],
-        )
+    name = result.group(3).strip()
+    amount = result.group(1).strip()
+    unit = result.group(2)
+    if isinstance(unit, str):
+        unit = unit.strip()
+    if not unit:
+        unit = None
+    return Ingredient(name, amount, unit)
 
 def splitCommand(line):
     r = r'^\s*([a-zA-Z]+)\s*:\s*(.*)'

--- a/pieces.py
+++ b/pieces.py
@@ -159,7 +159,10 @@ class Recipe(object):
         self.source = source
         self.author = author
         self.phases = phases
-        self.description = description
+        if isinstance(description, str):
+            self.description = [description]
+        else:
+            self.description = description
         self.keywords = keywords
         self.images = images
 
@@ -179,7 +182,9 @@ class Recipe(object):
         if self.author is not None:
             etree.SubElement(m, 'author').text = self.author
         if self.description is not None:
-            etree.SubElement(m, 'description').text = self.description
+            desc = etree.SubElement(m, 'description')
+            for p in self.description:
+                etree.SubElement(desc, 'p').text = p
         if self.keywords:
             kwe = etree.SubElement(m, 'keywords')
             for kw in self.keywords:

--- a/pieces.py
+++ b/pieces.py
@@ -74,6 +74,26 @@ class WaitPhase(object):
             return NotImplemented
         return self.text != other.text
 
+class Part(object):
+    def __init__(self, text = None):
+        self.text = text
+
+    def serialize(self, element):
+        etree.SubElement(element, 'part').text = self.text
+
+    def __repr__(self):
+        return 'Part({!r})'.format(self.text)
+
+    def __eq__(self, other):
+        if not isinstance(other, Part):
+            return NotImplemented
+        return self.text == other.text
+
+    def __ne__(self, other):
+        if not isinstance(other, Part):
+            return NotImplemented
+        return self.text != other.text
+
 class Phase(object):
     def __init__(self, ingredients = None, steps = None):
         if ingredients is None:

--- a/pieces.py
+++ b/pieces.py
@@ -54,6 +54,26 @@ class Step(object):
             return NotImplemented
         return self.text != other.text
 
+class Note(object):
+    def __init__(self, text):
+        self.text = text
+
+    def serialize(self, element):
+        e = etree.SubElement(element, 'note').text = self.text
+
+    def __repr__(self):
+        return 'Note({!r})'.format(self.text)
+
+    def __eq__(self, other):
+        if not isinstance(other, Note):
+            return NotImplemented
+        return self.text == other.text
+
+    def __ne__(self, other):
+        if not isinstance(other, Note):
+            return NotImplemented
+        return self.text != other.text
+
 class WaitPhase(object):
     def __init__(self, text = None):
         self.text = text

--- a/recipe2html.xslt
+++ b/recipe2html.xslt
@@ -51,8 +51,9 @@
                     div.source {
                         font-size:0.8em;
                     }
-                    
-                    div.description {
+
+                    div.description p {
+                        margin-top: 0px;
                         margin-bottom:0.3em;
                     }
                     
@@ -198,6 +199,10 @@
 
     <xsl:template match="meta/images/img">
         <div class="image"><img src="{text()}" /></div>
+    </xsl:template>
+
+    <xsl:template match="meta/description/p">
+        <p><xsl:apply-templates /></p>
     </xsl:template>
     
     <xsl:template match="phase">

--- a/recipe2html.xslt
+++ b/recipe2html.xslt
@@ -87,6 +87,12 @@
                         padding-bottom:0.3em;
                     }
 
+                    td.part {
+                        font-weight: bold;
+                        padding-top:0.3em;
+                        padding-bottom:0.3em;
+                    }
+
                     /* stretch the steps column to container width */
                     th:last-child, td:last-child {
                         width:100%;
@@ -206,6 +212,9 @@
 
     <xsl:template match="waitphase">
         <tr><td colspan="3" class="waitphase"><xsl:value-of select="text()" /></td></tr>
+    </xsl:template>
+    <xsl:template match="part">
+        <tr><td colspan="3" class="part"><xsl:value-of select="text()" /></td></tr>
     </xsl:template>
 </xsl:stylesheet>
 

--- a/recipe2html.xslt
+++ b/recipe2html.xslt
@@ -118,6 +118,19 @@
                         margin-right:0.4em;
                         margin-top:0.2em;
                     }
+                    .noteMarker {
+                        width: 1.2em;
+                        height: 1.2em;
+                        padding: 1px;
+                        text-align: center;
+                        vertical-align:middle;
+
+                        font: 0.7em Arial, sans-serif;
+                        line-height:1.2em;
+                        display:inline-block;
+                        margin-right:0.4em;
+                        margin-top:0.2em;
+                    }
                 </style>
             </head>
             <body>
@@ -193,12 +206,17 @@
             <td class="amount"><xsl:for-each select="ingredient"><xsl:value-of select="amount/text()" /><xsl:text> </xsl:text><xsl:value-of select="unit/text()" /><br /></xsl:for-each></td>
             <td class="step">
                 <div style="display:container;margin:0;padding:0">
-                    <xsl:for-each select="step">
+                    <xsl:for-each select="step | note">
                         <div style="display:table-row">
                              <div style="display:table-cell;vertical-align:top">
-                                 <div class="numberCircle" style="float:left">
-                                    <xsl:value-of select="count(ancestor::recipe/descendant::step[count(.|current()/preceding::step)=count(current()/preceding::step)])+1" />
-                                 </div>
+                                <xsl:choose>
+                                    <xsl:when test="local-name(.) = 'step'">
+                                        <div class="numberCircle" style="float:left"><xsl:value-of select="count(ancestor::recipe/descendant::step[count(.|current()/preceding::step)=count(current()/preceding::step)])+1" /> </div>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <div class="noteMarker" style="float:left">➤</div>
+                                    </xsl:otherwise>
+                                </xsl:choose>
                              </div>
                              <div style="display:table-cell">
                                 <xsl:value-of select="text()" />

--- a/test_parser.py
+++ b/test_parser.py
@@ -24,7 +24,7 @@ class LineTest(unittest.TestCase):
         self.assertNotEqual(Line(Line.Step, 23, 'mix'), Line(Line.Step, 42, 'mix'))
         self.assertNotEqual(Line(Line.Step, 23, 'mix'), Line(Line.Step, 23, 'fry'))
 
-class preprocesssLinesTest(unittest.TestCase):
+class preprocessLinesTest(unittest.TestCase):
     def test_linetypes(self):
         lines = list(preprocessLines(StringIO(preprocessLines_input['linetypes'])))
         self.assertEqual(lines, preprocessLines_result['linetypes'])

--- a/test_parser.py
+++ b/test_parser.py
@@ -177,6 +177,7 @@ test_input = {
         + lie down a bit
         * 100g meat
         - eat meat
+        # test part
         + never try this
         - this""",
     'multi_recipe' : """
@@ -270,6 +271,7 @@ test_result = {
                         Step('eat meat')
                         ]
                     ),
+                Part('test part'),
                 WaitPhase('never try this'),
                 Phase(
                     None,

--- a/test_parser.py
+++ b/test_parser.py
@@ -31,6 +31,22 @@ class parseIngredientTest(unittest.TestCase):
         i = parseIngredient('diced onion')
         self.assertEqual(i, Ingredient('diced onion', None, None))
 
+    def test_explicit(self):
+        i = parseIngredient('about 25 [g] butter')
+        self.assertEqual(i, Ingredient('butter', 'about 25', 'g'))
+
+    def test_explicit_nospaces(self):
+        i = parseIngredient('about 25[g]butter')
+        self.assertEqual(i, Ingredient('butter', 'about 25', 'g'))
+
+    def test_explicit_long_unit(self):
+        i = parseIngredient('1 [ heaped tbsp. ] sugar')
+        self.assertEqual(i, Ingredient('sugar', '1', 'heaped tbsp.'))
+
+    def test_explicit_nounit(self):
+        i = parseIngredient('as needed [] salt')
+        self.assertEqual(i, Ingredient('salt', 'as needed', None))
+
 class parseMetaTest(unittest.TestCase):
     def test_title(self):
         r = Recipe()

--- a/test_parser.py
+++ b/test_parser.py
@@ -153,27 +153,27 @@ class parseFileTest(unittest.TestCase):
 test_input = {
     'simple' : """
         ! title: the title
-        # 25g butter
-        * eat butter   """,
+        * 25g butter
+        - eat butter   """,
     'images' : """
         ! title: with images
         !img: image one.jpg
         !img: folder/image two.jpg
-        # 25g butter
-        * eat butter   """,
+        * 25g butter
+        - eat butter   """,
     'multiphase' : """
         ! title: the title
-        # 25g butter
-        * eat butter
+        * 25g butter
+        - eat butter
         + lie down a bit
-        # 100g meat
-        * eat meat
+        * 100g meat
+        - eat meat
         + never try this
-        * this""",
+        - this""",
     'multi_recipe' : """
         ! title: rec 1
         ! desc: simple description
-        # something
+        * something
         !title: rec 2
 
         a not so simple description

--- a/test_parser.py
+++ b/test_parser.py
@@ -150,6 +150,15 @@ class parseFileTest(unittest.TestCase):
         self.assertIsNotNone(context.exception.__cause__)
         self.assertEqual(context.exception.__cause__.args[0], 'invalid metadata key')
 
+    def test_invalid_error(self):
+        with self.assertRaises(RecipeParseError) as context:
+            parseFile(StringIO(test_input['invalid_error']))
+
+        self.assertEqual(context.exception.line, 'this line is invalid')
+        self.assertEqual(context.exception.line_nr, 5)
+        self.assertIsNotNone(context.exception.__cause__)
+        self.assertEqual(context.exception.__cause__.args[0], 'plain lines are only allowed for description at the beginning of the recipe')
+
 test_input = {
     'simple' : """
         ! title: the title
@@ -182,6 +191,11 @@ test_input = {
     'meta_error' : """
         !title: error
         ! unknown: foo""",
+    'invalid_error': """
+        !title: recipe with invalid line
+        * something
+
+        this line is invalid""",
     }
 
 test_result = {

--- a/test_parser.py
+++ b/test_parser.py
@@ -96,7 +96,7 @@ class parseMetaTest(unittest.TestCase):
         m = parseMeta(key, value, r)
         key, value = splitCommand('desc: second block')
         m = parseMeta(key, value, r)
-        self.assertEqual(r, Recipe(None, None, None, None, None, 'first block second block'))
+        self.assertEqual(r, Recipe(None, None, None, None, None, ['first block', 'second block']))
 
     def test_keyword(self):
         r = Recipe()

--- a/test_parser.py
+++ b/test_parser.py
@@ -174,6 +174,7 @@ test_input = {
         ! title: the title
         * 25g butter
         - eat butter
+        -- don't choke
         + lie down a bit
         * 100g meat
         - eat meat
@@ -259,7 +260,8 @@ test_result = {
                         Ingredient('butter', '25', 'g'),
                         ],
                     [
-                        Step('eat butter')
+                        Step('eat butter'),
+                        Note('don\'t choke')
                         ]
                     ),
                 WaitPhase('lie down a bit'),

--- a/test_pieces.py
+++ b/test_pieces.py
@@ -146,7 +146,7 @@ class RecipeTest(unittest.TestCase, XmlTestMixin, RealEqualMixin):
         self.assertEqual(r.lang, 'de')
         self.assertEqual(r.source, 'source')
         self.assertEqual(r.author, 'author')
-        self.assertEqual(r.description, 'description')
+        self.assertEqual(r.description, ['description'])
         self.assertEqual(r.phases, [])
 
         p = Phase()
@@ -169,7 +169,7 @@ class RecipeTest(unittest.TestCase, XmlTestMixin, RealEqualMixin):
     
     def test_repr(self):
         r = Recipe('title', 'size', 'de', 'source', 'author', 'description')
-        self.assertEqual(repr(r), "Recipe('title', 'size', 'de', 'source', 'author', 'description', [], [])")
+        self.assertEqual(repr(r), "Recipe('title', 'size', 'de', 'source', 'author', ['description'], [], [])")
 
     def test_compare(self):
         i = Ingredient('foo', None, None)
@@ -212,7 +212,9 @@ serialization = {
                        <lang>de</lang>
                        <source>source</source>
                        <author>author</author>
-                       <description>description</description>
+                       <description>
+                         <p>description</p>
+                       </description>
                        <keywords>
                          <keyword>k1</keyword>
                          <keyword>k2</keyword>

--- a/test_pieces.py
+++ b/test_pieces.py
@@ -80,6 +80,26 @@ class StepTest(unittest.TestCase, XmlTestMixin, RealEqualMixin):
         self.assertRealEqual(Step('foo'), Step('foo'))
         self.assertRealNotEqual(Step('foo'), Step('bar'))
 
+class NoteTest(unittest.TestCase, XmlTestMixin, RealEqualMixin):
+    def test_init(self):
+        n = Note('text')
+        self.assertEqual(n.text, 'text')
+
+    def test_serialize(self):
+        n = Note('text')
+        e = etree.Element('root')
+        n.serialize(e)
+
+        self.assertXmlEqual(etree.tounicode(e), serialization['note'])
+
+    def test_repr(self):
+        n = Note('text')
+        self.assertEqual(repr(n),"Note('text')")
+
+    def test_compare(self):
+        self.assertRealEqual(Note('foo'), Note('foo'))
+        self.assertRealNotEqual(Note('foo'), Note('bar'))
+
 class WaitPhaseTest(unittest.TestCase, XmlTestMixin, RealEqualMixin):
     def test_init(self):
         h = WaitPhase('text')
@@ -99,6 +119,26 @@ class WaitPhaseTest(unittest.TestCase, XmlTestMixin, RealEqualMixin):
     def test_compare(self):
         self.assertRealEqual(WaitPhase('foo'), WaitPhase('foo'))
         self.assertRealNotEqual(WaitPhase('foo'), WaitPhase('bar'))
+
+class PartTest(unittest.TestCase, XmlTestMixin, RealEqualMixin):
+    def test_init(self):
+        p = Part('text')
+        self.assertEqual(p.text, 'text')
+
+    def test_serialize(self):
+        p = Part('text')
+        e = etree.Element('root')
+        p.serialize(e)
+
+        self.assertXmlEqual(etree.tounicode(e), serialization['part'])
+
+    def test_repr(self):
+        p = Part('text')
+        self.assertEqual(repr(p),"Part('text')")
+
+    def test_compare(self):
+        self.assertRealEqual(Part('foo'), Part('foo'))
+        self.assertRealNotEqual(Part('foo'), Part('bar'))
 
 class PhaseTest(unittest.TestCase, XmlTestMixin, RealEqualMixin):
     def test_init(self):
@@ -202,7 +242,9 @@ serialization = {
         'noamount' : '<root><ingredient><name>name</name></ingredient></root>',
     },
     'step' : '<root><step>text</step></root>',
+    'note' : '<root><note>text</note></root>',
     'waitphase' : '<root><waitphase>text</waitphase></root>',
+    'part' : '<root><part>text</part></root>',
     'phase': '<root><phase><ingredient>...</ingredient><step>step1</step><step>step2</step></phase></root>',
     'recipe': """<root>
                    <recipe>


### PR DESCRIPTION
Yes, this is a lot, but it would have been quite messy and slow to separate all of this and create different pull requests.

This implements a lot of the features we have discussed previously:
- static word wrapping can be used in the markup
- optional explicit ingredient syntax using []
- changing the starting characters for ingredients and steps (the added conversion script migrate.py worked without problems for my recipe collection)
- add support for parts (using #)
- add support for notes (using --)
- add support for descriptions with multiple paragraphs
